### PR TITLE
[GAZ-253] Fix batch summary counts and tenant routing for closedloop transfers

### DIFF
--- a/src/main/java/org/mifos/connector/phee/camel/routes/BatchDetailRoute.java
+++ b/src/main/java/org/mifos/connector/phee/camel/routes/BatchDetailRoute.java
@@ -82,9 +82,11 @@ public class BatchDetailRoute extends BaseRouteBuilder {
                     String batchId = exchange.getProperty(BATCH_ID, String.class);
                     String pageNo = exchange.getProperty(PAGE_NO, String.class);
                     String pageSize = exchange.getProperty("pageSize", String.class);
+                    String tenantId = exchange.getProperty("tenantId", String.class);
                     String url = operationsAppConfig.batchDetailUrl + "?batchId=" + batchId + "&pageNo=" + pageNo + "&pageSize=" + pageSize;
                     exchange.getIn().setHeader(Exchange.HTTP_URI, url);
-                    logger.info("Calling operations-app batch detail: {}", url);
+                    exchange.getIn().setHeader("Platform-TenantId", tenantId);
+                    logger.info("Calling operations-app batch detail: {} tenant: {}", url, tenantId);
                 })
                 .toD("${header.CamelHttpUri}")
                 .log("API Response from operations-app: ${body}")

--- a/src/main/java/org/mifos/connector/phee/zeebe/workers/implementation/BatchSummaryWorker.java
+++ b/src/main/java/org/mifos/connector/phee/zeebe/workers/implementation/BatchSummaryWorker.java
@@ -74,20 +74,29 @@ public class BatchSummaryWorker extends BaseWorker {
 
             variables.put(MAX_RETRY_COUNT, maxRetryCount);
             variables.put(CURRENT_RETRY_COUNT, ++currentRetryCount);
-            variables.put(ONGOING_TRANSACTION, batchDTO.getOngoing());
-            variables.put(FAILED_TRANSACTION, batchDTO.getFailed());
-            variables.put(TOTAL_TRANSACTION, batchDTO.getTotal());
-            variables.put(COMPLETED_TRANSACTION, batchDTO.getSuccessful());
-            variables.put(ONGOING_AMOUNT, batchDTO.getPendingAmount());
-            variables.put(FAILED_AMOUNT, batchDTO.getFailedAmount());
-            variables.put(COMPLETED_AMOUNT, batchDTO.getSuccessfulAmount());
-            variables.put(TOTAL_AMOUNT, batchDTO.getTotalAmount());
-            long percentage = (long)(((double)
-                    (batchDTO.getSuccessful() + batchDTO.getFailed())/batchDTO.getTotal()) *100);
-            variables.put(COMPLETION_RATE, percentage);
 
-            if(batchDTO!=null) {
+            // Check if Zeebe already has counts pre-populated (closedloop path sets these in BatchTransferWorker)
+            long preSetTotal = variables.containsKey(TOTAL_TRANSACTION) ?
+                    ((Number) variables.get(TOTAL_TRANSACTION)).longValue() : 0L;
+            boolean hasMockPaymentSchemaData = batchDTO != null && batchDTO.getTotal() != null && batchDTO.getTotal() > 0;
 
+            if (hasMockPaymentSchemaData) {
+                // Normal path (mojaloop): use mock-payment-schema values
+                variables.put(ONGOING_TRANSACTION, batchDTO.getOngoing());
+                variables.put(FAILED_TRANSACTION, batchDTO.getFailed());
+                variables.put(TOTAL_TRANSACTION, batchDTO.getTotal());
+                variables.put(COMPLETED_TRANSACTION, batchDTO.getSuccessful());
+                variables.put(ONGOING_AMOUNT, batchDTO.getPendingAmount());
+                variables.put(FAILED_AMOUNT, batchDTO.getFailedAmount());
+                variables.put(COMPLETED_AMOUNT, batchDTO.getSuccessfulAmount());
+                variables.put(TOTAL_AMOUNT, batchDTO.getTotalAmount());
+                long percentage = (long)(((double)
+                        (batchDTO.getSuccessful() + batchDTO.getFailed()) / batchDTO.getTotal()) * 100);
+                variables.put(COMPLETION_RATE, percentage);
+                variables.put(BATCH_SUMMARY_SUCCESS, true);
+            } else if (preSetTotal > 0) {
+                // Closedloop path: counts already set by BatchTransferWorker — keep them, just signal success
+                logger.info("mock-payment-schema returned 0/null total but Zeebe has pre-set counts (total={}). Using pre-set values (closedloop path).", preSetTotal);
                 variables.put(BATCH_SUMMARY_SUCCESS, true);
             } else {
                 variables.put(ERROR_CODE, exchange.getProperty(ERROR_CODE));

--- a/src/main/java/org/mifos/connector/phee/zeebe/workers/implementation/BatchTransferWorker.java
+++ b/src/main/java/org/mifos/connector/phee/zeebe/workers/implementation/BatchTransferWorker.java
@@ -87,6 +87,9 @@ public class BatchTransferWorker extends BaseWorker {
     @Autowired
     private PaymentModeConfiguration paymentModeConfiguration;
 
+    @Autowired
+    private org.mifos.connector.phee.config.MockPaymentSchemaConfig mockPaymentSchemaConfig;
+
     @Value("${tenant}")
     public String tenant;
 
@@ -123,9 +126,40 @@ public class BatchTransferWorker extends BaseWorker {
             else if("closedloop".equalsIgnoreCase(paymentMode)){
                 logger.info("Processing closedloop batch transfer via channel connector");
                 String batchId = (String) variables.get(BATCH_ID);
-                boolean success = processClosedloopTransfers(transactionList, batchId, debulkingDfspId);
-                variables.put(INIT_BATCH_TRANSFER_SUCCESS, success);
-                logger.info("Closedloop processing complete. Success: {}, batchId: {}", success, batchId);
+                int[] counts = processClosedloopTransfers(transactionList, batchId, debulkingDfspId);
+                int successCount = counts[0];
+                int failureCount = counts[1];
+                long total = transactionList.size();
+
+                variables.put(INIT_BATCH_TRANSFER_SUCCESS, failureCount == 0);
+
+                // Pre-populate batch summary counts so BatchSummaryWorker can use them
+                // if mock-payment-schema returns 0 (it is not informed of closedloop results)
+                variables.put(TOTAL_TRANSACTION, total);
+                variables.put(COMPLETED_TRANSACTION, (long) successCount);
+                variables.put(FAILED_TRANSACTION, (long) failureCount);
+                variables.put(ONGOING_TRANSACTION, 0L);
+
+                double totalAmt = transactionList.stream()
+                        .mapToDouble(t -> t.getAmount() != null ? Double.parseDouble(t.getAmount()) : 0.0)
+                        .sum();
+                double failedAmt = transactionList.stream()
+                        .skip(successCount)
+                        .mapToDouble(t -> t.getAmount() != null ? Double.parseDouble(t.getAmount()) : 0.0)
+                        .sum();
+                double completedAmt = totalAmt - failedAmt;
+                variables.put(TOTAL_AMOUNT, totalAmt);
+                variables.put(COMPLETED_AMOUNT, completedAmt);
+                variables.put(FAILED_AMOUNT, failedAmt);
+                variables.put(ONGOING_AMOUNT, 0.0);
+                variables.put(COMPLETION_RATE, total > 0 ? (long)(((double)(successCount + failureCount) / total) * 100) : 0L);
+
+                logger.info("Closedloop processing complete. Success: {}, Failed: {}, batchId: {}",
+                        successCount, failureCount, batchId);
+
+                // Register actual results with mock-payment-schema so its summary endpoint returns real data
+                registerClosedloopSummary(batchId, debulkingDfspId, total, successCount, failureCount,
+                        totalAmt, completedAmt, failedAmt);
             }
             else{
                 String updatedCsvData = updateCsvDataPaymentMode(csvData, filePath);
@@ -326,7 +360,43 @@ public class BatchTransferWorker extends BaseWorker {
         return jsonWebSignature.getSignature(privateKeyString);
     }
 
-    private boolean processClosedloopTransfers(List<Transaction> transactionList, String batchId, String tenant) {
+    private void registerClosedloopSummary(String batchId, String tenant, long total, int successCount,
+            int failureCount, double totalAmt, double completedAmt, double failedAmt) {
+        try {
+            String url = mockPaymentSchemaConfig.mockPaymentSchemaContactPoint + "/batches/" + batchId + "/summary";
+
+            Map<String, Object> body = new HashMap<>();
+            body.put("batchId", batchId);
+            body.put("total", total);
+            body.put("successful", (long) successCount);
+            body.put("failed", (long) failureCount);
+            body.put("ongoing", 0L);
+            body.put("totalAmount", totalAmt);
+            body.put("successfulAmount", completedAmt);
+            body.put("failedAmount", failedAmt);
+            body.put("pendingAmount", 0.0);
+            body.put("status", failureCount == 0 ? "COMPLETED" : "PARTIALLY_COMPLETED");
+            long successPct = total > 0 ? (long) (((double) successCount / total) * 100) : 0L;
+            body.put("successPercentage", String.valueOf(successPct));
+            body.put("failPercentage", String.valueOf(100 - successPct));
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            headers.set("Platform-TenantId", tenant);
+
+            ObjectMapper objectMapper = new ObjectMapper();
+            HttpEntity<String> requestEntity = new HttpEntity<>(objectMapper.writeValueAsString(body), headers);
+
+            RestTemplate restTemplate = createRestTemplate();
+            restTemplate.exchange(url, HttpMethod.PUT, requestEntity, Void.class);
+            logger.info("## CLOSEDLOOP - Registered summary with mock-payment-schema: batchId={}, total={}, success={}, failed={}",
+                    batchId, total, successCount, failureCount);
+        } catch (Exception e) {
+            logger.warn("## CLOSEDLOOP - Failed to register summary with mock-payment-schema: {}", e.getMessage());
+        }
+    }
+
+    private int[] processClosedloopTransfers(List<Transaction> transactionList, String batchId, String tenant) {
         logger.info("## CLOSEDLOOP - Processing {} transactions for batchId: {}", transactionList.size(), batchId);
 
         int successCount = 0;
@@ -361,7 +431,7 @@ public class BatchTransferWorker extends BaseWorker {
         logger.info("## CLOSEDLOOP - Batch {} complete. Success: {}, Failed: {}",
             batchId, successCount, failureCount);
 
-        return failureCount == 0;
+        return new int[]{successCount, failureCount};
     }
 
     private boolean invokeChannelTransfer(Transaction transaction, String batchId, String tenant) {


### PR DESCRIPTION
Fixes from testing govstack closedloop and mojaloop on arm and X64_86

- BatchTransferWorker: After processing a closedloop batch, registers real transaction counts (total/completed/failed) to mock-payment-schema via a new PUT endpoint, so downstream workers have accurate data.
- BatchSummaryWorker: Three-way resolution — uses mock-payment-schema stored data, pre-set Zeebe variables, or raises an incident.
- BatchDetailRoute: Adds missing Platform-TenantId header to batch detail API calls, preventing HTTP 500 errors

https://mifosforge.jira.com/browse/GAZ-253