### PR TITLE
PHEE-372: Migrate to Spring Boot 3.4 / JDK 21 / Jakarta EE 10 / Camel 4 (via Mifos Platform BOM)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17-jdk
+FROM eclipse-temurin:21-jre
 EXPOSE 8080
 
 COPY build/libs/*.jar .

--- a/build.gradle
+++ b/build.gradle
@@ -1,15 +1,16 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '2.5.5'
-	id 'io.spring.dependency-management' version '1.1.0'
+	id 'org.springframework.boot' version '3.4.4'
+	id 'io.spring.dependency-management' version '1.1.6'
 	id 'idea'
-	id "org.springdoc.openapi-gradle-plugin" version "1.6.0"
+	id "org.springdoc.openapi-gradle-plugin" version "1.9.0"
 	id 'eclipse'
 }
 
 group = 'org.mifos'
 version = '2.0.0.mifos-SNAPSHOT'
-sourceCompatibility = '17'
+sourceCompatibility = JavaVersion.VERSION_21
+targetCompatibility = JavaVersion.VERSION_21
 
 
 repositories {
@@ -20,40 +21,55 @@ repositories {
     }
     maven {
         url = uri('https://mifos.jfrog.io/artifactory/phee-gradle-local')
-    }    
+    }
     maven {
         url = uri('https://mifos.jfrog.io/artifactory/mifosx-gradle-local')
     }
-}
 
-ext {
-	camelVersion = '3.18.1'
-	zeebClientVersion = '1.3.1'
+    // Mifos Platform BOM + ph-ee-connector-common 2.0.0-SNAPSHOT are consumed
+    // from the local JFrog Artifactory sandbox (Docker Compose in
+    // proposal/local-jfrog/). Swap this host for the production Mifos JFrog
+    // when the official BOM is ready.
+    maven {
+        name = 'LocalJFrog'
+        url = uri('http://localhost:8081/artifactory/mifos-platform-snapshot')
+        allowInsecureProtocol = true
+        credentials {
+            username = findProperty('localJfrog.user') ?: System.getenv('LOCAL_JFROG_USER')
+            password = findProperty('localJfrog.key') ?: System.getenv('LOCAL_JFROG_KEY')
+        }
+    }
 }
 
 dependencies {
-	implementation 'com.google.code.gson:gson:2.8.9'
-	implementation 'org.json:json:20210307'
-	implementation 'org.mifos:ph-ee-connector-common:1.8.1-gazelle'
-	// implementation 'org.mifos:ph-ee-connector-common:1.8.1-SNAPSHOT'
-	implementation 'org.apache.camel.springboot:camel-spring-boot-starter:3.4.0'
-	implementation 'org.apache.camel:camel-undertow:3.4.0'
-	implementation 'org.springframework.boot:spring-boot-starter:2.5.2'
-	implementation 'org.springframework.boot:spring-boot-starter-web:2.5.2'
-	implementation 'org.springframework:spring-web:5.3.19'
-	implementation 'org.apache.camel:camel-http:3.4.0'
-	implementation 'com.amazonaws:aws-java-sdk:1.11.486'
-	implementation 'com.azure:azure-storage-blob:12.12.0'
-	implementation 'io.camunda:zeebe-client-java:1.1.0'
-	implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-csv:2.12.0'
-	//implementation 'org.springframework.kafka:spring-kafka:2.5.8.RELEASE'
-	implementation 'org.apache.camel:camel-jackson:3.4.0'
-	implementation 'org.apache.camel.springboot:camel-mail-starter:3.4.0'
-	implementation('io.rest-assured:rest-assured:4.4.0')
-	compileOnly 'org.projectlombok:lombok:1.18.24'
-	annotationProcessor 'org.projectlombok:lombok:1.18.24'
+	// Mifos Platform BOM pins Spring Boot 3.4, Camel 4, Zeebe 8, Jakarta EE 10
+	// and every other shared library version. Do NOT hardcode managed versions.
+	// This is a deployable application (leaf node), so use enforcedPlatform().
+	implementation enforcedPlatform('org.mifos.platform:mifos-platform-bom:1.0.0-SNAPSHOT')
 
-	implementation "org.springdoc:springdoc-openapi-ui:1.6.11"
+	implementation 'com.google.code.gson:gson'
+	implementation 'org.json:json'
+	implementation 'org.mifos:ph-ee-connector-common:2.0.0-SNAPSHOT'
+	implementation 'org.apache.camel.springboot:camel-spring-boot-starter'
+	implementation 'org.apache.camel:camel-undertow'
+	implementation 'org.springframework.boot:spring-boot-starter'
+	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework:spring-web'
+	implementation 'org.apache.camel:camel-http'
+	// AWS SDK v1 kept pinned: actually used by the storage code; v1 -> v2 is a
+	// code rewrite (different packages), out of scope for this surgical PR.
+	implementation 'com.amazonaws:aws-java-sdk:1.11.486'
+	implementation 'com.azure:azure-storage-blob'
+	implementation 'io.camunda:zeebe-client-java'
+	implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-csv'
+	//implementation 'org.springframework.kafka:spring-kafka:2.5.8.RELEASE'
+	implementation 'org.apache.camel:camel-jackson'
+	implementation 'org.apache.camel.springboot:camel-mail-starter'
+	implementation 'io.rest-assured:rest-assured'
+	compileOnly 'org.projectlombok:lombok'
+	annotationProcessor 'org.projectlombok:lombok'
+
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui'
 }
 
 tasks.named('test') {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/org/mifos/connector/phee/camel/config/HttpClientConfigurerTrustAllCACerts.java
+++ b/src/main/java/org/mifos/connector/phee/camel/config/HttpClientConfigurerTrustAllCACerts.java
@@ -1,32 +1,28 @@
 package org.mifos.connector.phee.camel.config;
 
-import org.apache.camel.component.http.HttpClientConfigurer;
-import org.apache.http.config.Registry;
-import org.apache.http.config.RegistryBuilder;
-import org.apache.http.conn.socket.ConnectionSocketFactory;
-import org.apache.http.conn.socket.PlainConnectionSocketFactory;
-import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
-import org.apache.http.conn.ssl.TrustStrategy;
-import org.apache.http.impl.client.HttpClientBuilder;
-import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
-import org.apache.http.ssl.SSLContextBuilder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import javax.net.ssl.HostnameVerifier;
-import javax.net.ssl.SSLContext;
 import java.security.KeyManagementException;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
-import java.security.cert.CertificateException;
-import java.security.cert.X509Certificate;
+import javax.net.ssl.SSLContext;
+import org.apache.camel.component.http.HttpClientConfigurer;
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
+import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;
+import org.apache.hc.client5.http.ssl.SSLConnectionSocketFactory;
+import org.apache.hc.client5.http.ssl.TrustAllStrategy;
+import org.apache.hc.core5.ssl.SSLContextBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+// Ported from Apache HttpClient 4 to HttpClient 5: camel-http in Camel 4 passes
+// an HC5 HttpClientBuilder to HttpClientConfigurer. Behaviour is unchanged
+// (trust all certificates, no hostname verification).
 public class HttpClientConfigurerTrustAllCACerts implements HttpClientConfigurer {
 
     public Logger logger = LoggerFactory.getLogger(this.getClass());
 
-    public HttpClientConfigurerTrustAllCACerts() {
-    }
+    public HttpClientConfigurerTrustAllCACerts() {}
 
     @Override
     public void configureHttpClient(HttpClientBuilder clientBuilder) {
@@ -34,33 +30,17 @@ public class HttpClientConfigurerTrustAllCACerts implements HttpClientConfigurer
         //
         SSLContext sslContext = null;
         try {
-            sslContext = new SSLContextBuilder().loadTrustMaterial(null, new TrustStrategy() {
-                public boolean isTrusted(X509Certificate[] arg0, String arg1) throws CertificateException {
-                    return true;
-                }
-            }).build();
+            sslContext = SSLContextBuilder.create().loadTrustMaterial(null, TrustAllStrategy.INSTANCE).build();
         } catch (KeyManagementException | NoSuchAlgorithmException | KeyStoreException e) {
-            e.printStackTrace();
+            logger.debug(e.getMessage());
         }
-        clientBuilder.setSslcontext( sslContext);
 
-        // don't check Hostnames, either.
-        //      -- use SSLConnectionSocketFactory.getDefaultHostnameVerifier(), if you don't want to weaken
-        HostnameVerifier hostnameVerifier = SSLConnectionSocketFactory.ALLOW_ALL_HOSTNAME_VERIFIER;
-
-        // here's the special part:
-        //      -- need to create an SSL Socket Factory, to use our weakened "trust strategy";
-        //      -- and create a Registry, to register it.
-        //
-        SSLConnectionSocketFactory sslSocketFactory = new SSLConnectionSocketFactory(sslContext, hostnameVerifier);
-        Registry<ConnectionSocketFactory> socketFactoryRegistry = RegistryBuilder.<ConnectionSocketFactory>create()
-                .register("http", PlainConnectionSocketFactory.getSocketFactory())
-                .register("https", sslSocketFactory)
-                .build();
-
-        // now, we create connection-manager using our Registry.
-        //      -- allows multi-threaded use
-        PoolingHttpClientConnectionManager connMgr = new PoolingHttpClientConnectionManager( socketFactoryRegistry);
+        // don't check Hostnames, either, and use our weakened trust strategy.
+        // In HttpClient 5 the TLS configuration travels with the connection
+        // manager instead of the client builder.
+        SSLConnectionSocketFactory sslSocketFactory = new SSLConnectionSocketFactory(sslContext, NoopHostnameVerifier.INSTANCE);
+        PoolingHttpClientConnectionManager connMgr = PoolingHttpClientConnectionManagerBuilder.create()
+                .setSSLSocketFactory(sslSocketFactory).build();
         clientBuilder.setConnectionManager(connMgr);
     }
 

--- a/src/main/java/org/mifos/connector/phee/config/MockPaymentSchemaConfig.java
+++ b/src/main/java/org/mifos/connector/phee/config/MockPaymentSchemaConfig.java
@@ -3,7 +3,7 @@ package org.mifos.connector.phee.config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 
 @Component
 public class MockPaymentSchemaConfig {

--- a/src/main/java/org/mifos/connector/phee/config/OperationsAppConfig.java
+++ b/src/main/java/org/mifos/connector/phee/config/OperationsAppConfig.java
@@ -3,7 +3,7 @@ package org.mifos.connector.phee.config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 
 @Component
 public class OperationsAppConfig {

--- a/src/main/java/org/mifos/connector/phee/zeebe/workers/BaseWorker.java
+++ b/src/main/java/org/mifos/connector/phee/zeebe/workers/BaseWorker.java
@@ -14,7 +14,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
-import javax.annotation.PostConstruct;
+import jakarta.annotation.PostConstruct;
 
 // TODO: Duplicate file (Also exists in <service-name>)
 @Component

--- a/src/main/java/org/mifos/connector/phee/zeebe/workers/implementation/BatchSummaryWorker.java
+++ b/src/main/java/org/mifos/connector/phee/zeebe/workers/implementation/BatchSummaryWorker.java
@@ -3,10 +3,13 @@ package org.mifos.connector.phee.zeebe.workers.implementation;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.camel.Exchange;
 import org.apache.camel.support.DefaultExchange;
-import org.apache.http.conn.ssl.NoopHostnameVerifier;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
-import org.apache.http.ssl.SSLContextBuilder;
+import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
+import org.apache.hc.client5.http.ssl.SSLConnectionSocketFactory;
+
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.core5.ssl.SSLContextBuilder;
 import org.mifos.connector.phee.config.MockPaymentSchemaConfig;
 import org.mifos.connector.phee.schema.BatchDTO;
 import org.mifos.connector.phee.zeebe.workers.BaseWorker;
@@ -111,8 +114,12 @@ public class BatchSummaryWorker extends BaseWorker {
     public BatchDTO callApi(String batchId, String tenant) throws NoSuchAlgorithmException, KeyStoreException, KeyManagementException {
         RestTemplate restTemplate = new RestTemplate();
         CloseableHttpClient httpClient = HttpClients.custom()
-                .setSSLContext(new SSLContextBuilder().loadTrustMaterial(null, (certificate, authType) -> true).build())
-                .setSSLHostnameVerifier(NoopHostnameVerifier.INSTANCE)
+                // HttpClient 5: TLS config moved onto the connection manager
+                .setConnectionManager(PoolingHttpClientConnectionManagerBuilder.create()
+                        .setSSLSocketFactory(new SSLConnectionSocketFactory(
+                                new SSLContextBuilder().loadTrustMaterial(null, (certificate, authType) -> true).build(),
+                                NoopHostnameVerifier.INSTANCE))
+                        .build())
                 .build();
         restTemplate.setRequestFactory(new HttpComponentsClientHttpRequestFactory(httpClient));
 

--- a/src/main/java/org/mifos/connector/phee/zeebe/workers/implementation/BatchTransferWorker.java
+++ b/src/main/java/org/mifos/connector/phee/zeebe/workers/implementation/BatchTransferWorker.java
@@ -6,10 +6,13 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SequenceWriter;
 import com.fasterxml.jackson.dataformat.csv.CsvMapper;
 import com.fasterxml.jackson.dataformat.csv.CsvSchema;
-import org.apache.http.conn.ssl.NoopHostnameVerifier;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
-import org.apache.http.ssl.SSLContextBuilder;
+import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
+import org.apache.hc.client5.http.ssl.SSLConnectionSocketFactory;
+
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.core5.ssl.SSLContextBuilder;
 import org.mifos.connector.common.util.JsonWebSignature;
 import org.mifos.connector.phee.config.PaymentModeConfiguration;
 import org.mifos.connector.phee.config.PaymentModeMapping;
@@ -242,8 +245,12 @@ public class BatchTransferWorker extends BaseWorker {
 
     private CloseableHttpClient createHttpClient() throws NoSuchAlgorithmException, KeyStoreException, KeyManagementException {
         return HttpClients.custom()
-                .setSSLContext(new SSLContextBuilder().loadTrustMaterial(null, (certificate, authType) -> true).build())
-                .setSSLHostnameVerifier(NoopHostnameVerifier.INSTANCE)
+                // HttpClient 5: TLS config moved onto the connection manager
+                .setConnectionManager(PoolingHttpClientConnectionManagerBuilder.create()
+                        .setSSLSocketFactory(new SSLConnectionSocketFactory(
+                                new SSLContextBuilder().loadTrustMaterial(null, (certificate, authType) -> true).build(),
+                                NoopHostnameVerifier.INSTANCE))
+                        .build())
                 .build();
     }
 

--- a/src/main/java/org/mifos/connector/phee/zeebe/workers/implementation/PayerRtpResponseWorker.java
+++ b/src/main/java/org/mifos/connector/phee/zeebe/workers/implementation/PayerRtpResponseWorker.java
@@ -1,10 +1,13 @@
 package org.mifos.connector.phee.zeebe.workers.implementation;
 
-import org.apache.http.conn.ssl.NoopHostnameVerifier;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClientBuilder;
-import org.apache.http.impl.client.HttpClients;
-import org.apache.http.ssl.SSLContextBuilder;
+import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
+import org.apache.hc.client5.http.ssl.SSLConnectionSocketFactory;
+
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.core5.ssl.SSLContextBuilder;
 import org.mifos.connector.phee.data.PayerRTPResponse;
 import org.mifos.connector.phee.data.ResponseDTO;
 import org.mifos.connector.phee.zeebe.workers.BaseWorker;
@@ -38,9 +41,13 @@ public class PayerRtpResponseWorker extends BaseWorker {
             RestTemplate restTemplate = new RestTemplate();
             HttpComponentsClientHttpRequestFactory requestFactory = new HttpComponentsClientHttpRequestFactory();
             CloseableHttpClient httpClient = HttpClients.custom()
-                    .setSSLContext(new SSLContextBuilder().loadTrustMaterial(null, (certificate, authType) -> true).build())
-                    .setSSLHostnameVerifier(NoopHostnameVerifier.INSTANCE)
-                    .build();
+                // HttpClient 5: TLS config moved onto the connection manager
+                .setConnectionManager(PoolingHttpClientConnectionManagerBuilder.create()
+                        .setSSLSocketFactory(new SSLConnectionSocketFactory(
+                                new SSLContextBuilder().loadTrustMaterial(null, (certificate, authType) -> true).build(),
+                                NoopHostnameVerifier.INSTANCE))
+                        .build())
+                .build();
             restTemplate.setRequestFactory(new HttpComponentsClientHttpRequestFactory(httpClient));
             String billId = (String) variables.get("billId");
             String transactionId = (String) variables.get("transactionId");


### PR DESCRIPTION
## What

Migrate this connector to **Spring Boot 3.4 / JDK 21 / Jakarta EE 10 / Apache Camel 4**. All versions come from the Mifos Platform BOM via `enforcedPlatform(...)` instead of being pinned by hand.

Surgical migration: `javax.*` -> `jakarta.*`, versions moved to the BOM, and the minimum changes needed to compile and run. No feature work, no refactoring.

## Main changes

- `build.gradle`: Spring Boot plugin -> 3.4, `io.spring.dependency-management`, `enforcedPlatform('org.mifos.platform:mifos-platform-bom:1.0.0-SNAPSHOT')`; hand-pinned versions removed. `ph-ee-connector-common` -> `2.0.0-SNAPSHOT` where used.
- `javax.*` -> `jakarta.*` imports.
- Dockerfile base image -> `21-jre`.
- Apache HttpClient 4->5 (configurer + 3 RestTemplate workers); Zeebe client -> 8.4.17 (no code change). Validated end-to-end on gazelle K3s: a real bulk payment (CLOSEDLOOP + GovStack) completes 4/4.

## Heads-up for review

- Depends on the Mifos Platform BOM (and `ph-ee-connector-common:2.0.0-SNAPSHOT` where used), **not yet published to the official Mifos JFrog**. Until then it builds against a local JFrog, so CI here will not pass until those are published upstream.

Draft - opening so we can review it together.
